### PR TITLE
motion split with more flexibility

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/MOTIONSPLIT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MOTIONSPLIT.java
@@ -392,7 +392,11 @@ public class MOTIONSPLIT extends ElementOrListStackFunction {
           }
         } else {
           if (null != splitTypeLabel) {
-            split.getMetadata().putToLabels(splitTypeLabel, SPLIT_TYPE_END);
+            if (proximityZoneSplit) {
+              split.getMetadata().putToLabels(splitTypeLabel, SPLIT_TYPE_MOVING);
+            } else {
+              split.getMetadata().putToLabels(splitTypeLabel, SPLIT_TYPE_END);
+            }
           }
         }
       }

--- a/warp10/src/main/java/io/warp10/script/functions/MOTIONSPLIT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MOTIONSPLIT.java
@@ -176,7 +176,7 @@ public class MOTIONSPLIT extends ElementOrListStackFunction {
 
         GeoTimeSerie gts = (GeoTimeSerie) element;
 
-        return motionSplit(gts, fsplitNumberLabel, ftimeThreshold, fdistanceThreshold, fproximityZoneRadius, fproximityZoneMaxSpeed, fproximityZoneTime, fproximityInZoneMaxMeanSpeed, fsplitTypeLabel, fstoppedTimeLabel,fproximityZoneSplit);
+        return motionSplit(gts, fsplitNumberLabel, ftimeThreshold, fdistanceThreshold, fproximityZoneRadius, fproximityZoneMaxSpeed, fproximityZoneTime, fproximityInZoneMaxMeanSpeed, fsplitTypeLabel, fstoppedTimeLabel, fproximityZoneSplit);
       }
     };
   }
@@ -191,7 +191,7 @@ public class MOTIONSPLIT extends ElementOrListStackFunction {
    * - time not moving, if datapoints stay within a certain area and no distance is traveled for a certain time, a split will happen
    *
    * @param gts                         GTS to split
-   * @param splitNumberLabel                  If set, add a label which will contain the start of the split
+   * @param splitNumberLabel            If set, add a label which will contain the start of the split
    * @param timeThreshold               If the delay between two ticks goes beyond this value, force a split
    * @param distanceThreshold           If we traveled more than distanceThreshold between two ticks, force a split
    * @param proximityZoneRadius         Radius of the proximity zone in meters.
@@ -280,7 +280,7 @@ public class MOTIONSPLIT extends ElementOrListStackFunction {
       // If the distance traveled in the proximity zone was traveled at less than proximityInZoneMaxMeanSpeed and the time spent in the zone is above proximityZoneTime, force a split
       //
       long timeStopped = previousTimestamp - refTimestamp;
-      if (GeoTimeSerie.NO_LOCATION != refLocation && GeoTimeSerie.NO_LOCATION != location ) {
+      if (GeoTimeSerie.NO_LOCATION != refLocation && GeoTimeSerie.NO_LOCATION != location) {
 
         double currentSpeed = 0.0D;
         if (GeoTimeSerie.NO_LOCATION != previousLocation && timestamp != previousTimestamp) {
@@ -325,18 +325,20 @@ public class MOTIONSPLIT extends ElementOrListStackFunction {
         //
         if (proximityZoneSplit && null != split && splitReason == SPLIT_TYPE_STOPPED) {
           long stopTimestamp = GTSHelper.lasttick(split) - timeStopped;
-          GeoTimeSerie moving = GTSHelper.timeclip(split,Long.MIN_VALUE,stopTimestamp);
-          GeoTimeSerie stopped = GTSHelper.timeclip(split,stopTimestamp,Long.MAX_VALUE);
-          if (null != splitTypeLabel) {
-            moving.getMetadata().putToLabels(splitTypeLabel, SPLIT_TYPE_MOVING);
+          if (stopTimestamp != GTSHelper.firsttick(split)) {
+            GeoTimeSerie moving = GTSHelper.timeclip(split, Long.MIN_VALUE, stopTimestamp);
+            GeoTimeSerie stopped = GTSHelper.timeclip(split, stopTimestamp, Long.MAX_VALUE);
+            if (null != splitTypeLabel) {
+              moving.getMetadata().putToLabels(splitTypeLabel, SPLIT_TYPE_MOVING);
+            }
+            if (null != splitNumberLabel) {
+              stopped.getMetadata().putToLabels(splitNumberLabel, Long.toString(gtsid));
+              gtsid++;
+            }
+            splits.remove(splits.size() - 1);
+            splits.add(moving);
+            splits.add(stopped);
           }
-          if (null != splitNumberLabel) {
-            stopped.getMetadata().putToLabels(splitNumberLabel, Long.toString(gtsid));
-            gtsid++;
-          }
-          splits.remove(splits.size() - 1);
-          splits.add(moving);
-          splits.add(stopped);
         }
 
         split = gts.cloneEmpty();
@@ -375,8 +377,8 @@ public class MOTIONSPLIT extends ElementOrListStackFunction {
           //
           if (proximityZoneSplit) {
             long stopTimestamp = GTSHelper.lasttick(split) - timeStopped;
-            GeoTimeSerie moving = GTSHelper.timeclip(split,Long.MIN_VALUE,stopTimestamp);
-            GeoTimeSerie stopped = GTSHelper.timeclip(split,stopTimestamp,Long.MAX_VALUE);
+            GeoTimeSerie moving = GTSHelper.timeclip(split, Long.MIN_VALUE, stopTimestamp);
+            GeoTimeSerie stopped = GTSHelper.timeclip(split, stopTimestamp, Long.MAX_VALUE);
             if (null != splitTypeLabel) {
               moving.getMetadata().putToLabels(splitTypeLabel, SPLIT_TYPE_MOVING);
             }

--- a/warp10/src/main/java/io/warp10/script/functions/MOTIONSPLIT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MOTIONSPLIT.java
@@ -17,6 +17,7 @@ package io.warp10.script.functions;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import com.geoxp.GeoXPLib;
 
@@ -32,174 +33,303 @@ import io.warp10.script.WarpScriptStack;
  */
 public class MOTIONSPLIT extends ElementOrListStackFunction {
 
+  public static final String PARAM_TIMESPLIT = "timesplit";
+  public static final String PARAM_START_LABEL = "label.split.start";
+  public static final String PARAM_PROXIMITY_IN_ZONE_TIME_LABEL = "label.stopped.time";
+  public static final String PARAM_SPLIT_TYPE_LABEL = "label.split.type";
+  public static final String PARAM_DISTANCETHRESHOLD = "distance.split";
+  public static final String PARAM_PROXIMITY_ZONE_TIME = "stopped.min.time";
+  public static final String PARAM_PROXIMITY_ZONE_SPEED = "stopped.max.speed";
+  public static final String PARAM_PROXIMITY_ZONE_RADIUS = "stopped.max.radius";
+  public static final String PARAM_PROXIMITY_IN_ZONE_MAX_SPEED = "stopped.max.mean.speed";
+
+  public static final String SPLIT_TYPE_TIME = "timesplit";
+  public static final String SPLIT_TYPE_DISTANCE = "distancesplit";
+  public static final String SPLIT_TYPE_END = "end";
+  public static final String SPLIT_TYPE_STOPPED = "stopped";
+
+
   public MOTIONSPLIT(String name) {
     super(name);
   }
-  
+
   @Override
   public ElementStackFunction generateFunction(WarpScriptStack stack) throws WarpScriptException {
+
+    Map<String, Object> params = null;
     Object top = stack.pop();
-    
-    if (!(top instanceof Number)) {
-      throw new WarpScriptException(getName() + " expects a proximity zone speed in m/s.");
+
+    if (!(top instanceof Map)) {
+      throw new WarpScriptException(getName() + " expects a parameter MAP on top of the stack.");
     }
-    
-    final double proximityZoneSpeed = ((Number) top).doubleValue();
-    
-    top = stack.pop();
-    
-    if (!(top instanceof Long)) {
-      throw new WarpScriptException(getName() + " expects a proximity zone time in time units.");
+
+    params = (Map) top;
+
+    long timeThreshold = Long.MAX_VALUE;
+    if (params.containsKey(PARAM_TIMESPLIT)) {
+      Object o = params.get((PARAM_TIMESPLIT));
+      if (!(o instanceof Number)) {
+        throw new WarpScriptException(getName() + " " + PARAM_TIMESPLIT + " must be a number.");
+      }
+      timeThreshold = ((Number) o).longValue();
     }
-    
-    final long proximityZoneTime = ((Long) top).longValue();
-    
-    top = stack.pop();
-    
-    if (!(top instanceof Number)) {
-      throw new WarpScriptException(getName() + " expects a proximity zone radius in meters.");
+
+    String startLabel = null;
+    if (params.containsKey(PARAM_START_LABEL)) {
+      Object o = params.get((PARAM_START_LABEL));
+      if (!(o instanceof String)) {
+        throw new WarpScriptException(getName() + " " + PARAM_START_LABEL + " must be a string.");
+      }
+      startLabel = o.toString();
     }
-    
-    final double proximityZoneRadius = ((Number) top).doubleValue();
-    
-    top = stack.pop();
-    
-    if (!(top instanceof Number)) {
-      throw new WarpScriptException(getName() + " expects a distance threshold in meters.");
+
+    String splitTypeLabel = null;
+    if (params.containsKey(PARAM_SPLIT_TYPE_LABEL)) {
+      Object o = params.get((PARAM_SPLIT_TYPE_LABEL));
+      if (!(o instanceof String)) {
+        throw new WarpScriptException(getName() + " " + PARAM_SPLIT_TYPE_LABEL + " must be a string.");
+      }
+      splitTypeLabel = o.toString();
     }
-    
-    final double distanceThreshold = ((Number) top).doubleValue();
-    
-    top = stack.pop();
-    
-    if (!(top instanceof Long)) {
-      throw new WarpScriptException(getName() + " expects a time threshold in time units.");
+
+    String stoppedTimeLabel = null;
+    if (params.containsKey(PARAM_PROXIMITY_IN_ZONE_TIME_LABEL)) {
+      Object o = params.get((PARAM_PROXIMITY_IN_ZONE_TIME_LABEL));
+      if (!(o instanceof String)) {
+        throw new WarpScriptException(getName() + " " + PARAM_PROXIMITY_IN_ZONE_TIME_LABEL + " must be a string.");
+      }
+      stoppedTimeLabel = o.toString();
     }
-    
-    final long timeThreshold = ((Long) top).longValue();
-    
-    top = stack.pop();
-    
-    if (!(top instanceof String)) {
-      throw new WarpScriptException(getName() + " expects a label name for splits.");
+
+    double distanceThreshold = Double.MAX_VALUE;
+    if (params.containsKey(PARAM_DISTANCETHRESHOLD)) {
+      Object o = params.get((PARAM_DISTANCETHRESHOLD));
+      if (!(o instanceof Number)) {
+        throw new WarpScriptException(getName() + " " + PARAM_DISTANCETHRESHOLD + " must be a number.");
+      }
+      distanceThreshold = ((Number) o).doubleValue();
     }
-    
-    final String label = top.toString();
-    
+
+    double proximityZoneMaxSpeed = Double.MAX_VALUE;
+    if (params.containsKey(PARAM_PROXIMITY_ZONE_SPEED)) {
+      Object o = params.get((PARAM_PROXIMITY_ZONE_SPEED));
+      if (!(o instanceof Number)) {
+        throw new WarpScriptException(getName() + " " + PARAM_PROXIMITY_ZONE_SPEED + " must be a number: speed in m/s.");
+      }
+      proximityZoneMaxSpeed = ((Number) o).doubleValue();
+    }
+
+    double proximityInZoneMaxMeanSpeed = Double.MAX_VALUE;
+    if (params.containsKey(PARAM_PROXIMITY_IN_ZONE_MAX_SPEED)) {
+      Object o = params.get((PARAM_PROXIMITY_IN_ZONE_MAX_SPEED));
+      if (!(o instanceof Number)) {
+        throw new WarpScriptException(getName() + " " + PARAM_PROXIMITY_IN_ZONE_MAX_SPEED + " must be a number: speed in m/s.");
+      }
+      proximityInZoneMaxMeanSpeed = ((Number) o).doubleValue();
+    }
+
+    long proximityZoneTime = Long.MAX_VALUE;
+    if (params.containsKey(PARAM_PROXIMITY_ZONE_TIME)) {
+      Object o = params.get((PARAM_PROXIMITY_ZONE_TIME));
+      if (!(o instanceof Number)) {
+        throw new WarpScriptException(getName() + " " + PARAM_PROXIMITY_ZONE_TIME + " must be a number: time in platform time unit");
+      }
+      proximityZoneTime = ((Number) o).longValue();
+    }
+
+    double proximityZoneRadius = Double.MAX_VALUE;
+    if (params.containsKey(PARAM_PROXIMITY_ZONE_RADIUS)) {
+      Object o = params.get((PARAM_PROXIMITY_ZONE_RADIUS));
+      if (!(o instanceof Number)) {
+        throw new WarpScriptException(getName() + " " + PARAM_PROXIMITY_ZONE_RADIUS + " must be a number: radius in meters.");
+      }
+      proximityZoneRadius = ((Number) o).doubleValue();
+    }
+
+    final String fstartLabel = startLabel;
+    final long ftimeThreshold = timeThreshold;
+    final double fdistanceThreshold = distanceThreshold;
+    final double fproximityZoneRadius = proximityZoneRadius;
+    final double fproximityZoneMaxSpeed = proximityZoneMaxSpeed;
+    final long fproximityZoneTime = proximityZoneTime;
+    final double fproximityInZoneMaxMeanSpeed = proximityInZoneMaxMeanSpeed;
+    final String fsplitTypeLabel = splitTypeLabel;
+    final String fstoppedTimeLabel = stoppedTimeLabel;
+
     return new ElementStackFunction() {
       @Override
       public Object applyOnElement(Object element) throws WarpScriptException {
         if (!(element instanceof GeoTimeSerie)) {
           throw new WarpScriptException(getName() + " can only be applied on Geo Time Series.");
         }
-        
+
         GeoTimeSerie gts = (GeoTimeSerie) element;
-        
-        return motionSplit(gts, label, timeThreshold, distanceThreshold, proximityZoneRadius, proximityZoneSpeed, proximityZoneTime);
+
+        return motionSplit(gts, fstartLabel, ftimeThreshold, fdistanceThreshold, fproximityZoneRadius, fproximityZoneMaxSpeed, fproximityZoneTime, fproximityInZoneMaxMeanSpeed, fsplitTypeLabel, fstoppedTimeLabel);
       }
     };
   }
-  
+
   /**
    * Split a Geo Time Series according to motion.
-   * 
+   * <p>
    * The criteria for splitting are:
-   * 
+   * <p>
    * - time between datapoints, above a certain threshold a split will happen
    * - distance between datapoints, above a certain threshold a split will happen
    * - time not moving, if datapoints stay within a certain area and no distance is traveled for a certain time, a split will happen
-   * 
-   * @param gts GTS to split
-   * @param label Name of label which will contain the start of the split
-   * @param timeThreshold If the delay between two ticks goes beyond this value, force a split
-   * @param distanceThreshold If we traveled more than distanceThreshold between two ticks, force a split
-   * @param proximityZoneRadius Radius of the proximity zone in meters
-   * @param proximityZoneTime If we spent more than that much time in the proximity zone without moving and traveled slower than proximityZoneSpeed while in the proximityZone force a split
-   * @param proximityZoneSpeed Minimum speed in the proxmityZone to prevent a split, in m/s
-   * 
+   *
+   * @param gts                         GTS to split
+   * @param startLabel                  If set, add a label which will contain the start of the split
+   * @param timeThreshold               If the delay between two ticks goes beyond this value, force a split
+   * @param distanceThreshold           If we traveled more than distanceThreshold between two ticks, force a split
+   * @param proximityZoneRadius         Radius of the proximity zone in meters.
+   * @param proximityZoneTime           If we spent more than that much time in the proximity zone without moving and traveled slower than proximityInZoneMaxMeanSpeed while in the proximityZone force a split
+   * @param proximityZoneMaxSpeed       Maximum instant speed to consider you are in the same proximity zone
+   * @param proximityInZoneMaxMeanSpeed Minimum mean speed in the proximityZone to prevent a split, in m/s
+   * @param splitTypeLabel              If set, add a label with the reason of the split
+   * @param stoppedTimeLabel            If set, add a label with the time in the stop state
    * @return
    * @throws WarpScriptException
    */
-  private static List<GeoTimeSerie> motionSplit(GeoTimeSerie gts, String label, long timeThreshold, double distanceThreshold, double proximityZoneRadius, double proximityZoneSpeed, long proximityZoneTime) throws WarpScriptException {
+  private static List<GeoTimeSerie> motionSplit(GeoTimeSerie gts, String startLabel, long timeThreshold, double distanceThreshold, double proximityZoneRadius, double proximityZoneMaxSpeed,
+                                                long proximityZoneTime, double proximityInZoneMaxMeanSpeed, String splitTypeLabel, String stoppedTimeLabel) throws WarpScriptException {
     //
     // Sort GTS according to timestamps
     //
-    
+
     GTSHelper.sort(gts, false);
 
     GeoTimeSerie split = null;
-    
+
     List<GeoTimeSerie> splits = new ArrayList<GeoTimeSerie>();
-    
+
     int idx = 0;
-    
+
     int n = GTSHelper.nvalues(gts);
-    
+
     boolean mustSplit = true;
 
     long refLocation = GeoTimeSerie.NO_LOCATION;
     long refTimestamp = Long.MIN_VALUE;
-    
+
     long previousTimestamp = Long.MIN_VALUE;
     long previousLocation = GeoTimeSerie.NO_LOCATION;
     double proximityZoneTraveledDistance = 0.0D;
-    
+
     while (idx < n) {
       long timestamp = GTSHelper.tickAtIndex(gts, idx);
       long location = GTSHelper.locationAtIndex(gts, idx);
       long elevation = GTSHelper.elevationAtIndex(gts, idx);
       Object value = GTSHelper.valueAtIndex(gts, idx);
-    
+
       //
-      // If the previous tick was more than 'timeThreashold' ago, split now
-      // If the distance to the previous location is above distanceThreshold, split
+      // Initialise refLocation as soon as there is a valid position
       //
-      
-      if (timestamp - previousTimestamp > timeThreshold
-          || (GeoTimeSerie.NO_LOCATION != previousLocation && GeoTimeSerie.NO_LOCATION != location && GeoXPLib.orthodromicDistance(location, previousLocation) > distanceThreshold)) {
+      if (GeoTimeSerie.NO_LOCATION == refLocation && GeoTimeSerie.NO_LOCATION != location) {
+        refLocation = location;
+        refTimestamp = timestamp;
+      }
+
+      //
+      // If the previous tick was more than 'timeThreshold' ago, split now
+      //
+      if (timestamp - previousTimestamp > timeThreshold) {
+        if (null != splitTypeLabel) {
+          split.getMetadata().putToLabels(splitTypeLabel, SPLIT_TYPE_TIME);
+        }
         mustSplit = true;
       }
-      
+
       //
-      // If the current point is farther away from the reference point than 'proximityZoneRadius'
-      // change the reference point and reset the traveled distance.
-      // If the distance traveled in the proximity zone was traveled at less than proximityZoneSpeed and the time spent in the zone is above proximityZoneTime, force a split
+      // If the distance to the previous location is above distanceThreshold, split
       //
-      
-      if (GeoTimeSerie.NO_LOCATION != refLocation && GeoTimeSerie.NO_LOCATION != location && GeoXPLib.orthodromicDistance(refLocation, location) > proximityZoneRadius) {
-        if (previousTimestamp - refTimestamp > proximityZoneTime && proximityZoneTraveledDistance / ((double) (previousTimestamp - refTimestamp) / Constants.TIME_UNITS_PER_S) < proximityZoneSpeed) {
-          mustSplit = true;
+      if (GeoTimeSerie.NO_LOCATION != previousLocation && GeoTimeSerie.NO_LOCATION != location && GeoXPLib.orthodromicDistance(location, previousLocation) > distanceThreshold) {
+        if (null != splitTypeLabel) {
+          split.getMetadata().putToLabels(splitTypeLabel, SPLIT_TYPE_DISTANCE);
         }
-        refLocation = location;
-        refTimestamp = timestamp;
-        proximityZoneTraveledDistance = 0.0D;
-      } else if (GeoTimeSerie.NO_LOCATION != refLocation && GeoTimeSerie.NO_LOCATION != location && GeoXPLib.orthodromicDistance(refLocation, location) <= proximityZoneRadius) {
-        if (GeoTimeSerie.NO_LOCATION != previousLocation) {
-          proximityZoneTraveledDistance += GeoXPLib.orthodromicDistance(previousLocation, location);
+        mustSplit = true;
+      }
+
+      //
+      // If the current point is farther away from the reference point than 'proximityZoneRadius', or the instant speed is greater than proximityZoneSpeed
+      // change the reference point and reset the traveled distance.
+      // If the distance traveled in the proximity zone was traveled at less than proximityInZoneMaxMeanSpeed and the time spent in the zone is above proximityZoneTime, force a split
+      //
+      long timeStopped = previousTimestamp - refTimestamp;
+      if (GeoTimeSerie.NO_LOCATION != refLocation && GeoTimeSerie.NO_LOCATION != location && null != split) {
+
+        double currentSpeed = 0.0D;
+        if (GeoTimeSerie.NO_LOCATION != previousLocation && timestamp != previousTimestamp) {
+          currentSpeed = GeoXPLib.orthodromicDistance(previousLocation, location) / ((double) (timestamp - previousTimestamp) / Constants.TIME_UNITS_PER_S);
+        }
+
+        // quit the radius, or speed greater than min speed.
+        if (GeoXPLib.orthodromicDistance(refLocation, location) > proximityZoneRadius || currentSpeed > proximityZoneMaxSpeed) {
+          double zoneMeanSpeed = 0.0D;
+          if (previousTimestamp != refTimestamp) {
+            zoneMeanSpeed = proximityZoneTraveledDistance / ((double) (previousTimestamp - refTimestamp) / Constants.TIME_UNITS_PER_S);
+          }
+          if (timeStopped > proximityZoneTime && zoneMeanSpeed < proximityInZoneMaxMeanSpeed) {
+            mustSplit = true;
+            if (null != stoppedTimeLabel) {
+              split.getMetadata().putToLabels(stoppedTimeLabel, Long.toString(timeStopped));
+            }
+            if (null != splitTypeLabel) {
+              split.getMetadata().putToLabels(splitTypeLabel, SPLIT_TYPE_STOPPED);
+            }
+          }
+          refLocation = location;
+          refTimestamp = timestamp;
+          proximityZoneTraveledDistance = 0.0D;
+        } else { // inside the radius
+          if (GeoTimeSerie.NO_LOCATION != previousLocation) {
+            proximityZoneTraveledDistance += GeoXPLib.orthodromicDistance(previousLocation, location);
+          }
         }
       }
-      
+
+      //
+      // mustSplit is also true on the first iteration
+      //
       if (mustSplit) {
         split = gts.cloneEmpty();
-        
-        split.getMetadata().putToLabels(label, Long.toString(timestamp));
-        
+
+        if (null != startLabel) {
+          split.getMetadata().putToLabels(startLabel, Long.toString(timestamp));
+        }
         splits.add(split);
         mustSplit = false;
-        
+
         refLocation = location;
         refTimestamp = timestamp;
         proximityZoneTraveledDistance = 0.0D;
       }
-      
+
       GTSHelper.setValue(split, timestamp, location, elevation, value, false);
+
+      //
+      // On the last iteration, also manage the split type label (end or stopped)
+      //
+      if (idx == n - 1) {
+        String splitType = SPLIT_TYPE_END;
+        if ((previousTimestamp - refTimestamp) > proximityZoneTime) {
+          splitType = SPLIT_TYPE_STOPPED;
+          if (null != stoppedTimeLabel) {
+            split.getMetadata().putToLabels(stoppedTimeLabel, Long.toString(timeStopped));
+          }
+        }
+        if (null != splitTypeLabel) {
+          split.getMetadata().putToLabels(splitTypeLabel, splitType);
+        }
+      }
 
       previousTimestamp = timestamp;
       previousLocation = location;
-      
+
       idx++;
     }
-            
+
     return splits;
   }
 }

--- a/warp10/src/main/java/io/warp10/script/functions/MOTIONSPLIT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MOTIONSPLIT.java
@@ -327,7 +327,7 @@ public class MOTIONSPLIT extends ElementOrListStackFunction {
           long stopTimestamp = GTSHelper.lasttick(split) - timeStopped;
           if (stopTimestamp != GTSHelper.firsttick(split)) {
             GeoTimeSerie moving = GTSHelper.timeclip(split, Long.MIN_VALUE, stopTimestamp);
-            GeoTimeSerie stopped = GTSHelper.timeclip(split, stopTimestamp, Long.MAX_VALUE);
+            GeoTimeSerie stopped = GTSHelper.timeclip(split, stopTimestamp + 1, Long.MAX_VALUE);
             if (null != splitTypeLabel) {
               moving.getMetadata().putToLabels(splitTypeLabel, SPLIT_TYPE_MOVING);
             }
@@ -378,7 +378,7 @@ public class MOTIONSPLIT extends ElementOrListStackFunction {
           if (proximityZoneSplit) {
             long stopTimestamp = GTSHelper.lasttick(split) - timeStopped;
             GeoTimeSerie moving = GTSHelper.timeclip(split, Long.MIN_VALUE, stopTimestamp);
-            GeoTimeSerie stopped = GTSHelper.timeclip(split, stopTimestamp, Long.MAX_VALUE);
+            GeoTimeSerie stopped = GTSHelper.timeclip(split, stopTimestamp + 1, Long.MAX_VALUE);
             if (null != splitTypeLabel) {
               moving.getMetadata().putToLabels(splitTypeLabel, SPLIT_TYPE_MOVING);
             }

--- a/warp10/src/main/java/io/warp10/script/functions/MOTIONSPLIT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MOTIONSPLIT.java
@@ -325,7 +325,7 @@ public class MOTIONSPLIT extends ElementOrListStackFunction {
         //
         // Split again the current split if proximityZoneSplit is set
         //
-        if (proximityZoneSplit && null != split && splitReason == SPLIT_TYPE_STOPPED) {
+        if (proximityZoneSplit && null != split && SPLIT_TYPE_STOPPED.equals(splitReason)) {
           long stopTimestamp = GTSHelper.lasttick(split) - timeStopped;
           if (stopTimestamp != GTSHelper.firsttick(split)) {
             GeoTimeSerie moving = GTSHelper.timeclip(split, Long.MIN_VALUE, stopTimestamp);

--- a/warp10/src/main/java/io/warp10/script/functions/MOTIONSPLIT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MOTIONSPLIT.java
@@ -365,7 +365,6 @@ public class MOTIONSPLIT extends ElementOrListStackFunction {
       // On the last iteration, also manage the split type label (end or stopped), and split again if needed
       //
       if (idx == n - 1) {
-        splitReason = SPLIT_TYPE_END;
         if ((previousTimestamp - refTimestamp) > proximityZoneTime) {
           splitReason = SPLIT_TYPE_STOPPED;
           if (null != stoppedTimeLabel) {
@@ -390,6 +389,10 @@ public class MOTIONSPLIT extends ElementOrListStackFunction {
             splits.remove(splits.size() - 1);
             splits.add(moving);
             splits.add(stopped);
+          }
+        } else {
+          if (null != splitTypeLabel) {
+            split.getMetadata().putToLabels(splitTypeLabel, SPLIT_TYPE_END);
           }
         }
       }


### PR DESCRIPTION
Slight change to introduce more flexibility...


## do nothing
```
$gts 
{ }
MOTIONSPLIT
```
![image](https://user-images.githubusercontent.com/37228740/68405346-3b446080-0180-11ea-9310-456d51e07c8b.png)

## time split, more than 10.95s between datapoints
```
$gts 
{ 
 'timesplit' 10.95 s 
}
MOTIONSPLIT
```
![image](https://user-images.githubusercontent.com/37228740/68405569-a2621500-0180-11ea-81bd-566fd9453f79.png)



## distance split, 100 m trigger
```
$gts 
{ 
 'timesplit' 10.95 s 
 'distance.split' 100
}
MOTIONSPLIT
```
![image](https://user-images.githubusercontent.com/37228740/68405544-95452600-0180-11ea-9c5f-303fee290218.png)

## combine, and add extra labels to output
```
$gts 
 //1573135239233178 1160575178 TIMECLIP // cut the final stop
{
  'timesplit' 10.95 s 
  'distance.split' 100
  'label.split.start' 'split'
  'label.split.type' 'reason'
}
MOTIONSPLIT
```
![image](https://user-images.githubusercontent.com/37228740/68405645-c4f42e00-0180-11ea-80be-b4c05d3d2912.png)

## stop detection split, simplest (time in an area), stop time label

```
$gts 
1573135239233178 1160575178 TIMECLIP // cut the final stop
{
  'stopped.min.time'  60 s
  'stopped.max.radius' 80
  'label.stopped.time' 'stop_time'
  'label.split.start' 'split'
  'label.split.type' 'reason'
}
MOTIONSPLIT
```
![image](https://user-images.githubusercontent.com/37228740/68405903-3207c380-0181-11ea-9d85-a7827e0681b9.png)

## stop detection split, with a maximum speed to consider stop
why ? Because when driving again, there is this extra point in the proximity zone, 
![image](https://user-images.githubusercontent.com/37228740/68405946-42b83980-0181-11ea-9b56-06150733a4f8.png)
```
<% 3.6 / %> 'km/h' STORE
$gts 
{
  'stopped.min.time'  60 s
  'stopped.max.speed' 10 @km/h
  'stopped.max.radius' 80
  'label.stopped.time' 'stop_time'
  'label.split.start' 'split'
  'label.split.type' 'reason'
}
MOTIONSPLIT
```
now it is OK:
![image](https://user-images.githubusercontent.com/37228740/68406188-a5a9d080-0181-11ea-83df-4c696da1a078.png)

## stop detection split, with a maximum mean speed in the proximity zone that prevent the split

It will split only if there is a full stop during the given time and radius, and if the mean speed in the proximity zone is less than 1km/h
```
$gts
{
  'stopped.min.time'  60 s
  'stopped.max.speed' 10 @km/h
  'stopped.max.radius' 80
  'stopped.max.mean.speed' 1 @km/h
  
  'label.stopped.time' 'stop_time'
  'label.split.start' 'split'
  'label.split.type' 'reason'
}
MOTIONSPLIT
```
![image](https://user-images.githubusercontent.com/37228740/68406570-557f3e00-0182-11ea-85b3-8a449b628d60.png)

## combining everything
```
$gts 
{
  'timesplit' 10.95 s 
  'distance.split' 100
  'stopped.min.time'  60 s
  'stopped.max.speed' 10 @km/h
  'stopped.max.radius' 80
  'stopped.max.mean.speed' 5 @km/h
  'label.stopped.time' 'stop_time'
  'label.split.start' 'split'
  'label.split.type' 'reason'
}
MOTIONSPLIT
```
![image](https://user-images.githubusercontent.com/37228740/68406738-98411600-0182-11ea-9f27-2b639c1192ca.png)


## purpose of stopped time in label
The label.stopped.time add an extra label with the time stopped. It is easy to split again later to isolate the stopped state. If you want, I can add this feature in the MOTIONSPLIT too.
```
$gts 
{
  'stopped.min.time'  60 s
  'stopped.max.speed' 10 @km/h
  'stopped.max.radius' 80
  'stopped.max.mean.speed' 5 @km/h
  'label.stopped.time' 'stop_time'
  'label.split.start' 'split'
  'label.split.type' 'reason'
}
MOTIONSPLIT

<%
  DROP
  'g' STORE
  $g LABELS 'stop_time' GET 'ts' STORE
  <% $ts ISNULL ! %>
  <%
    $g LASTTICK  $ts TOLONG - 'break' STORE
    $g [ [ MINLONG $break ]  [ $break MAXLONG ] ] CLIP
    DUP 1 GET { 'state' 'STOP' } RELABEL DROP 
    DUP 0 GET { 'state' 'RUN' } RELABEL DROP 
  %> 
  <%
    $g
  %>
  IFTE
%>
LFLATMAP
```
![image](https://user-images.githubusercontent.com/37228740/68407022-1ef5f300-0183-11ea-9594-7b70b0026c99.png)

## Split reason priority
Stopped > distance split > time split > end of sequence