### PR TITLE
Fix parseDuration handling of negative subseconds

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/DURATION.java
+++ b/warp10/src/main/java/io/warp10/script/functions/DURATION.java
@@ -24,6 +24,8 @@ import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
 
 import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.joda.time.Duration;
 import org.joda.time.Instant;
@@ -42,6 +44,8 @@ public class DURATION extends NamedWarpScriptFunction implements WarpScriptStack
 
   final private static Double STU = new Double(Constants.TIME_UNITS_PER_S);
 
+  final private static Pattern NEGATIVE_ZERO_SECONDS_PATTERN = Pattern.compile(".*-0+$");
+
   public DURATION(String name) {
     super(name);
   }
@@ -55,7 +59,6 @@ public class DURATION extends NamedWarpScriptFunction implements WarpScriptStack
       throw new WarpScriptException(getName() + " expects an ISO8601 duration (a string) on top of the stack. See http://en.wikipedia.org/wiki/ISO_8601#Durations");
     }
 
-    // Separate seconds from digits below second precision
     String duration_string = o.toString();
 
     try {
@@ -68,10 +71,18 @@ public class DURATION extends NamedWarpScriptFunction implements WarpScriptStack
     return stack;
   }
 
-  public static long parseDuration(Instant ref, String duration_string, boolean allowAmbiguous, boolean negate) throws WarpScriptException {
+  public static long parseDuration(Instant ref, String duration_string, boolean allowAmbiguous, boolean toRef) throws WarpScriptException {
+    // Handle "-PTxxx" which is valid but not handled by Joda.
+    long globalSignFactor = 1;
+    if (duration_string.startsWith("-")) {
+      duration_string = duration_string.substring(1);
+      globalSignFactor = -1;
+    }
+
+    // Separate seconds from digits below second precision
     String[] tokens = UnsafeString.split(duration_string, '.');
 
-    long offset = 0;
+    long subseconds = 0;
 
     if (tokens.length > 2) {
       throw new WarpScriptException("invalid ISO8601 duration.");
@@ -81,7 +92,7 @@ public class DURATION extends NamedWarpScriptFunction implements WarpScriptStack
       duration_string = tokens[0].concat("S");
       String tmp = tokens[1].substring(0, tokens[1].length() - 1);
       Double d_offset = Double.valueOf("0." + tmp) * STU;
-      offset = d_offset.longValue();
+      subseconds = d_offset.longValue();
     }
 
     ReadWritablePeriod period = new MutablePeriod();
@@ -94,23 +105,24 @@ public class DURATION extends NamedWarpScriptFunction implements WarpScriptStack
       throw new WarpScriptException("no support for ambiguous durations containing years or months, please convert those to days.");
     }
 
-    Duration duration = negate ? p.toDurationTo(ref) : p.toDurationFrom(ref);
+    Duration duration = toRef ? p.toDurationTo(ref) : p.toDurationFrom(ref);
 
     // Find out if subseconds are positive or negative.
-    boolean offsetIsNegative = false;
+    boolean negativeSubseconds = false;
     if (p.getSeconds() < 0) {
       // Seconds are negative, so as subseconds (example: -1.234).
-      offsetIsNegative = true;
-    } else if (0 == p.getSeconds() && 2 == tokens.length) {
+      negativeSubseconds = true;
+    } else if (0 == p.getSeconds() && 0 != subseconds) {
       // There aren't whole seconds and subseconds are defined (example: 0.123).
       // Check if there is a minus sign before any number of 0s defining seconds.
-      offsetIsNegative = tokens[0].matches(".*-0+$");
+      Matcher negativeZeroSecondMatcher = NEGATIVE_ZERO_SECONDS_PATTERN.matcher(tokens[0]);
+      negativeSubseconds = negativeZeroSecondMatcher.matches();
     }
 
-    if (offsetIsNegative ^ negate) {
-      offset = -offset;
+    if (negativeSubseconds) {
+      subseconds = -subseconds;
     }
 
-    return duration.getMillis() * Constants.TIME_UNITS_PER_MS + offset;
+    return globalSignFactor * (duration.getMillis() * Constants.TIME_UNITS_PER_MS + subseconds);
   }
 }

--- a/warp10/src/main/java/io/warp10/script/functions/DURATION.java
+++ b/warp10/src/main/java/io/warp10/script/functions/DURATION.java
@@ -96,7 +96,18 @@ public class DURATION extends NamedWarpScriptFunction implements WarpScriptStack
 
     Duration duration = negate ? p.toDurationTo(ref) : p.toDurationFrom(ref);
 
-    if (duration.getMillis() < 0) {
+    // Find out if subseconds are positive or negative.
+    boolean offsetIsNegative = false;
+    if (p.getSeconds() < 0) {
+      // Seconds are negative, so as subseconds (example: -1.234).
+      offsetIsNegative = true;
+    } else if (0 == p.getSeconds() && 2 == tokens.length) {
+      // There aren't whole seconds and subseconds are defined (example: 0.123).
+      // Check if there is a minus sign before any number of 0s defining seconds.
+      offsetIsNegative = tokens[0].matches(".*-0+$");
+    }
+
+    if (offsetIsNegative ^ negate) {
       offset = -offset;
     }
 


### PR DESCRIPTION
`'PT-0.1S' DURATION` now returns `-100000` although the duration of the period is 0.

Checking `duration.getMillis() < 0` will not work in the case of `PT-1M59.9S` for instance. The overall duration is negative but the subsecond part is positive.