### PR TITLE
More call fixes

### DIFF
--- a/etc/conf.templates/distributed/20-warpscript.conf.template
+++ b/etc/conf.templates/distributed/20-warpscript.conf.template
@@ -181,6 +181,10 @@ warpscript.delete.endpoint = http://127.0.0.1:8080/api/v0/delete
 //
 #warpscript.call.maxcapacity = 1
 
+//
+// Maximum amount of time each attempt to access a process will wait (in ms). Defaults to 10000 ms.
+//
+#warpscript.call.maxwait = 10000
 
 //
 // Path of the 'bootstrap' WarpScript code for Mobius

--- a/etc/conf.templates/standalone/20-warpscript.conf.template
+++ b/etc/conf.templates/standalone/20-warpscript.conf.template
@@ -181,6 +181,11 @@ warpscript.delete.endpoint = http://${standalone.host}:${standalone.port}/api/v0
 #warpscript.call.maxcapacity = 1
 
 //
+// Maximum amount of time each attempt to access a process will wait (in ms). Defaults to 10000 ms.
+//
+#warpscript.call.maxwait = 10000
+
+//
 // Path of the 'bootstrap' WarpScript code for Mobius
 //
 warpscript.mobius.bootstrap.path = ${standalone.home}/etc/bootstrap/mobius.mc2

--- a/warp10/src/main/java/io/warp10/script/functions/CALL.java
+++ b/warp10/src/main/java/io/warp10/script/functions/CALL.java
@@ -24,6 +24,7 @@ import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
 import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.warp.sdk.Capabilities;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +41,6 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
 import java.util.concurrent.locks.ReentrantLock;
-
 /**
  * Call a subprogram
  */
@@ -246,10 +246,10 @@ public class CALL extends NamedWarpScriptFunction implements WarpScriptStackFunc
         // Ignore previous possible unexpected output from the process, warn user in the logs
         //
         BufferedReader br = subprograms.get(subprogram).getReader(proc);
-        String o;
+        String sbr;
         while (br.ready()) {
-          o = br.readLine();
-          LOG.warn("skipping unexpected CALL output from " + subprogram.toString() + " (" + o.substring(0, 1000) + "...)");
+          sbr = br.readLine();
+          LOG.warn("skipping unexpected CALL output from " + subprogram.toString() + " (" + StringUtils.substring(sbr, 0, 1000) + "...)");
         }
 
         //

--- a/warp10/src/main/java/io/warp10/script/functions/CALL.java
+++ b/warp10/src/main/java/io/warp10/script/functions/CALL.java
@@ -24,6 +24,8 @@ import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
 import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.warp.sdk.Capabilities;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -35,7 +37,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
 import java.util.concurrent.locks.ReentrantLock;
@@ -44,6 +45,8 @@ import java.util.concurrent.locks.ReentrantLock;
  * Call a subprogram
  */
 public class CALL extends NamedWarpScriptFunction implements WarpScriptStackFunction {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CALL.class);
 
   private static int maxCapacity;
 
@@ -72,6 +75,25 @@ public class CALL extends NamedWarpScriptFunction implements WarpScriptStackFunc
 
     public ProcessPool(String path) {
       this.builder = new ProcessBuilder(path);
+
+      // Make sure to terminate child processes
+      Thread hook = new Thread() {
+        @Override
+        public void run() {
+          Process proc = null;
+          try {
+            while (!processes.isEmpty()) {
+              proc = processes.remove(0);
+              LOG.info("Ending CALL subprocess " + path);
+              proc.destroy();
+            }
+          } catch (Exception e) {
+            LOG.warn("Error ending CALL subprocess" + path);
+          }
+        }
+      };
+
+      Runtime.getRuntime().addShutdownHook(hook);
     }
 
     public void provision() throws IOException {
@@ -208,7 +230,7 @@ public class CALL extends NamedWarpScriptFunction implements WarpScriptStackFunc
       maxWait = Long.parseLong(Capabilities.get(stack, MAXWAIT_CAPABILITY));
     }
 
-    while(attempts > 0) {
+    while (attempts > 0) {
       Process proc = null;
 
       try {
@@ -220,6 +242,16 @@ public class CALL extends NamedWarpScriptFunction implements WarpScriptStackFunc
           throw new WarpScriptException(getName() + " unable to acquire subprogram.");
         }
 
+        // 
+        // Ignore previous possible unexpected output from the process, warn user in the logs
+        //
+        BufferedReader br = subprograms.get(subprogram).getReader(proc);
+        String o;
+        while (br.ready()) {
+          o = br.readLine();
+          LOG.warn("skipping unexpected CALL output from " + subprogram.toString() + " (" + o.substring(0, 1000) + "...)");
+        }
+
         //
         // Output the URLencoded string to the subprogram
         //
@@ -227,8 +259,6 @@ public class CALL extends NamedWarpScriptFunction implements WarpScriptStackFunc
         proc.getOutputStream().write(WarpURLEncoder.encode(args.toString(), StandardCharsets.UTF_8).getBytes(StandardCharsets.UTF_8));
         proc.getOutputStream().write('\n');
         proc.getOutputStream().flush();
-
-        BufferedReader br = subprograms.get(subprogram).getReader(proc);
 
         String ret = br.readLine();
 


### PR DESCRIPTION
- Avoid perpetual sync loss between input and output
- Kill the processes at the end (because if the called process start another thread, it never exits)
- Added maxwait to config templates.

Heavily tested.


